### PR TITLE
Trimmed video title of spaces and tabs

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ async function downloadCourse(courseId, cookie) {
             await wait(137000 * index);
             // Add numbering for proper sequencing
             // Strip title of illegal chars
-            const title = `${index + 1}. ${video.title.replace(/[:?*'|&;$%@"<>()+,\/]/g, "")}`;
+            const title = `${index + 1}. ${video.title.trim().replace(/[:?*'|&;$%@"<>()+,\/]/g, "")}`;
 
             console.log(`Retrieving metadata for: ${title}`);
 


### PR DESCRIPTION
Some videos were not downloaded due to tabs and spaces in their title. This will fix the issue.